### PR TITLE
fix: Prevent workflow from running on push

### DIFF
--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   protect-all-repositories:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       # Шаг 1: Основная логика поиска и защиты веток


### PR DESCRIPTION
This PR adds a condition to the protect.yml workflow to prevent it from running on push events and causing failures.